### PR TITLE
Allow usage of SRP accessions directly

### DIFF
--- a/geo_to_hca/geo_to_hca.py
+++ b/geo_to_hca/geo_to_hca.py
@@ -109,6 +109,7 @@ def create_spreadsheet_using_geo_accession(accession, nthreads= 1, hca_template=
     Initialise a study accession string.
     """
     srp_accession = None
+    geo_accession = None
 
     """
     Check the study accession type. Is it a GEO database study accession or SRA study accession? if GEO, fetch the
@@ -116,6 +117,7 @@ def create_spreadsheet_using_geo_accession(accession, nthreads= 1, hca_template=
     """
 
     if 'GSE' in accession:
+        geo_accession = accession
         log.info(f"Fetching SRA study ID for GEO dataset {accession}")
         srp_accession = fetch_srp_accession(accession)
         log.info(f"Found SRA study ID: {srp_accession}")
@@ -205,7 +207,7 @@ def create_spreadsheet_using_geo_accession(accession, nthreads= 1, hca_template=
         """
         log.info(f"Getting project metadata")
         project_name, project_title, project_description, project_pubmed_id = get_tab.get_project_main_tab_xls(
-            srp_metadata_update, workbook, accession, tab_name="Project")
+            srp_metadata_update, workbook, geo_accession, tab_name="Project")
 
         try:
             """

--- a/geo_to_hca/utils/get_tab.py
+++ b/geo_to_hca/utils/get_tab.py
@@ -287,7 +287,7 @@ def update_sequence_file_tab_xls(sequence_file_tab: pd.DataFrame,library_protoco
 def get_project_main_tab_xls(srp_metadata_update: pd.DataFrame,workbook: object,geo_accession: str,tab_name: str) -> []:
     """
     Fills and writes a Project (main) tab with SRA study and Bioproject metadata obtained via a request to the NCBI SRA database
-    with a bioporject accession.
+    with a bioproject accession.
     """
     study = list(srp_metadata_update['SRAStudy'])[0]
     project = list(srp_metadata_update['BioProject'])[0]

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ install_requires = [line.rstrip() for line in (HERE / "requirements.txt").read_t
 
 setup(
     name="geo-to-hca",
-    version="1.0.7",
+    version="1.0.8",
     description="A tool to assist in the automatic conversion of geo metadata to hca metadata standard",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
dcp-707

Allows usage of SRP accessions so that when an SRP accession is given, it's not set as the GEO accession